### PR TITLE
DateTimePlugin: Update every second

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ out
 firmware.map
 upload.json
 *.code-workspace
+.DS_Store

--- a/src/Plugin/Plugins/DateTimePlugin.cpp
+++ b/src/Plugin/Plugins/DateTimePlugin.cpp
@@ -333,10 +333,10 @@ void DateTimePlugin::updateDateTime(bool force)
         {
             /* Show the time only in case
              * its forced to do it or
-             * the minute changed.
+             * the time changed.
              */
             if ((true == force) ||
-                (m_shownMinute != timeInfo.tm_min))
+                (m_shownSecond != timeInfo.tm_sec))
             {
                 const String&   timeFormat      = clockDrv.getTimeFormat();
                 String          extTimeFormat   = "\\calign" + timeFormat;
@@ -346,7 +346,7 @@ void DateTimePlugin::updateDateTime(bool force)
                 {
                     m_textWidget.setFormatStr(timeAsStr);
 
-                    m_shownMinute       = timeInfo.tm_min;
+                    m_shownSecond       = timeInfo.tm_sec;
                     m_isUpdateAvailable = true;
                 }
                 

--- a/src/Plugin/Plugins/DateTimePlugin.h
+++ b/src/Plugin/Plugins/DateTimePlugin.h
@@ -83,7 +83,7 @@ public:
         m_cfg(CFG_DATE_TIME),
         m_checkUpdateTimer(),
         m_durationCounter(0u),
-        m_shownMinute(-1),
+        m_shownSecond(-1),
         m_shownDayOfTheYear(-1),
         m_isUpdateAvailable(false),
         m_slotInterf(nullptr),
@@ -285,7 +285,8 @@ private:
     Cfg                     m_cfg;                      /**< Configuration about what shall be shown. */
     SimpleTimer             m_checkUpdateTimer;         /**< Timer, used for cyclic check if date/time update is necessary. */
     uint8_t                 m_durationCounter;          /**< Variable to count the Plugin duration in CHECK_UPDATE_PERIOD ticks . */
-    int                     m_shownMinute;              /**< Used to trigger a display update in case the time shall be shown. [0; 59] */
+    int                     m_shownSecond;              /**< Used to trigger a display update in case the time shall be shown. [0; 59] */
+
     int                     m_shownDayOfTheYear;        /**< Used to trigger a display update in case the date shall be shown. [0; 365] */
     bool                    m_isUpdateAvailable;        /**< Flag to indicate an updated date value. */
     const ISlotPlugin*      m_slotInterf;               /**< Slot interface */


### PR DESCRIPTION
Increase update frequency of DateTimePlugin from minute to second.
This allows to use Pixelix as a digitial clock with also accurate second display.