### PR TITLE
Fix issue #139: S3: Switch to official eSPI_TFT library

### DIFF
--- a/config/display.ini
+++ b/config/display.ini
@@ -109,7 +109,7 @@ build_flags =
 lib_deps_builtin =
     HalTftDisplay
 lib_deps_external =
-    https://github.com/nhjschulz/TFT_eSPI
+    bodmer/TFT_eSPI @ ~2.5.31
 lib_ignore_builtin =
     HalLedMatrix
 lib_ignore_external =


### PR DESCRIPTION
S3 support meanwhile part of bodmer/TFT_eSPI.
Remove temporary patched versiom which had
compile time warnings.