### PR TITLE
Development: Add Analog clock display to 64x64 HUB75 DateTimePlugin

### DIFF
--- a/lib/DateTimePlugin/src/DateTimePlugin.cpp
+++ b/lib/DateTimePlugin/src/DateTimePlugin.cpp
@@ -400,7 +400,14 @@ void DateTimePlugin::updateDateTime(bool force)
             /* Should never happen. */
             m_mode = MODE_DATE_TIME;
             break;
-        };
+        }
+
+        /* cache time every second in view  (i.e. for analog clock) */
+        if ((true == force) ||
+            (m_shownSecond != timeInfo.tm_sec))
+        {
+            m_view.setCurrentTime(timeInfo);
+        }
 
         if (true == showTime)
         {
@@ -419,9 +426,7 @@ void DateTimePlugin::updateDateTime(bool force)
                     m_view.setFormatText(timeAsStr);
 
                     m_shownSecond = timeInfo.tm_sec;
-                }
-                
-                m_view.setWeekdayIndicator(timeInfo);
+                } 
             }
         }
         else if (true == showDate)
@@ -441,9 +446,7 @@ void DateTimePlugin::updateDateTime(bool force)
                     m_view.setFormatText(dateAsStr);
 
                     m_shownDayOfTheYear = timeInfo.tm_yday;
-                }
-                
-                m_view.setWeekdayIndicator(timeInfo);
+                }              
             }
         }
         else

--- a/lib/Views/src/IDateTimeView.h
+++ b/lib/Views/src/IDateTimeView.h
@@ -145,11 +145,11 @@ public:
     virtual void setDayOffColor(const Color& color) = 0;
 
     /**
-     * Set weekday indicator depended on the given time info.
-     *
-     * @param[in] timeInfo the current time info.
+     * @brief Update current time values in view
+     * 
+     * @param now current time
      */
-    virtual void setWeekdayIndicator(tm timeInfo) = 0;
+    virtual void setCurrentTime(const tm& now) = 0;
 
 protected:
 

--- a/lib/Views/src/IDateTimeView.h
+++ b/lib/Views/src/IDateTimeView.h
@@ -145,7 +145,7 @@ public:
     virtual void setDayOffColor(const Color& color) = 0;
 
     /**
-     * @brief Update current time values in view
+     * @brief Update current time values in view.
      * 
      * @param now current time
      */

--- a/lib/Views/src/layouts/DateTimeView32x8.cpp
+++ b/lib/Views/src/layouts/DateTimeView32x8.cpp
@@ -64,10 +64,12 @@ const Color DateTimeView32x8::DAY_OFF_COLOR = ColorDef::ULTRADARKGRAY;
  * Public Methods
  *****************************************************************************/
 
-void DateTimeView32x8::setWeekdayIndicator(tm timeInfo)
+void DateTimeView32x8::setCurrentTime(const tm& now)
 {
+    /* update lamp widgets */
+
     /* tm_wday starts at sunday, first lamp indicates monday.*/
-    uint8_t activeLamp = (0U < timeInfo.tm_wday) ? (timeInfo.tm_wday - 1U) : (MAX_LAMPS - 1U);
+    uint8_t activeLamp = (0U < now.tm_wday) ? (now.tm_wday - 1U) : (MAX_LAMPS - 1U);
 
     /* Last active lamp has to be deactivated. */
     uint8_t lampToDeactivate = (0U < activeLamp) ? (activeLamp - 1U) : (MAX_LAMPS - 1U);

--- a/lib/Views/src/layouts/DateTimeView32x8.h
+++ b/lib/Views/src/layouts/DateTimeView32x8.h
@@ -219,8 +219,8 @@ public:
         updateLampWidgetsColors();
     }
 
-/**
-     * @brief Update current time values in view
+    /**
+     * @brief Update current time values in view.
      * 
      * @param now current time
      */

--- a/lib/Views/src/layouts/DateTimeView32x8.h
+++ b/lib/Views/src/layouts/DateTimeView32x8.h
@@ -222,7 +222,7 @@ public:
     /**
      * @brief Update current time values in view.
      * 
-     * @param now current time
+     * @param[in] now current time
      */
     virtual void setCurrentTime(const tm& now) override;
 

--- a/lib/Views/src/layouts/DateTimeView32x8.h
+++ b/lib/Views/src/layouts/DateTimeView32x8.h
@@ -219,12 +219,12 @@ public:
         updateLampWidgetsColors();
     }
 
-    /**
-     * Set weekday indicator depended on the given time info.
-     *
-     * @param[in] timeInfo the current time info.
+/**
+     * @brief Update current time values in view
+     * 
+     * @param now current time
      */
-    void setWeekdayIndicator(tm timeInfo) override;
+    virtual void setCurrentTime(const tm& now) override;
 
     /** Max. number of lamps. One lamp per day in a week. */
     static const uint8_t    MAX_LAMPS       = 7U;

--- a/lib/Views/src/layouts/DateTimeView64x64.cpp
+++ b/lib/Views/src/layouts/DateTimeView64x64.cpp
@@ -26,7 +26,9 @@
 *******************************************************************************/
 /**
  * @brief  View for 64x64 LED matrix with date and time.
+ *
  * @author Andreas Merkle <web@blue-andi.de>
+ * @author Norbert Schulz <github@schulznorbert.de>
  */
 
 /******************************************************************************
@@ -42,6 +44,9 @@
  * Macros
  *****************************************************************************/
 
+/** Factor by which Sinu/cosinus values are scaled to use integer math.  */
+static const int16_t SINUS_VAL_SCALE = 10000;
+
 /******************************************************************************
  * Types and classes
  *****************************************************************************/
@@ -50,37 +55,96 @@
  * Prototypes
  *****************************************************************************/
 
+/**
+* @brief Get the Minute Sinus value
+*
+* @param angle Minute angle, must be mutliple of 6°  (360 °/ 60 minutes)
+* @return sinus value for angle (scaled by 10.000)
+*/
+static int16_t getMinuteSinus(uint16_t angle);
+
+/**
+ * @brief Get the Minute Cosinus value
+ *
+ * @param angle Minute angle, must be mutliple of 6° (360 °/ 60 minutes)
+ * @return cosinus value for angle (scaled by 10.000)
+ */
+static int16_t getMinuteCosinus(uint16_t angle);
+
 /******************************************************************************
  * Local Variables
  *****************************************************************************/
 
-/* Initialize the color of the actual day. */
-const Color DateTimeView64x64::DAY_ON_COLOR  = ColorDef::LIGHTGRAY;
-
-/* Initialize the color of the other days (not the actual day). */
-const Color DateTimeView64x64::DAY_OFF_COLOR = ColorDef::ULTRADARKGRAY;
+/**
+  * Sinus lookup table for analog clock drawing
+  *
+  * Holds sinus values for the minutes 0 .. 15 angles in quadarant 0.
+  * Other quadrants and cosinus values get derived from these values
+  * to avoid recalculations.
+  *
+  * Sinus value are stored as integer scaled by 10.000.
+  */
+static const uint16_t MINUTE_SIN_TAB[16u] = {
+    0,    /* sin(0°)   */
+    1045, /* sin(6°)   */
+    2079, /* sin(12°)  */
+    3090, /* sin(18°)  */
+    4067, /* sin(24°)  */
+    4999, /* sin(30°)  */
+    5877, /* sin(36°)  */
+    6691, /* sin(42°)  */
+    7431, /* sin(48°)  */
+    8090, /* sin(54°)  */
+    8660, /* sin(60°)  */
+    9135, /* sin(66°)  */
+    9510, /* sin(72°)  */
+    9781, /* sin(78°)  */
+    9945, /* sin(84°)  */
+    10000 /* sin(90°)  */
+};
 
 /******************************************************************************
  * Public Methods
  *****************************************************************************/
 
-void DateTimeView64x64::setWeekdayIndicator(tm timeInfo)
+/**
+ * Update the underlying canvas.
+ *
+ * @param[in] gfx   Graphic functionality to draw on the underlying canvas.
+ */
+void DateTimeView64x64::update(YAGfx& gfx)
 {
-    /* tm_wday starts at sunday, first lamp indicates monday.*/
-    uint8_t activeLamp = (0U < timeInfo.tm_wday) ? (timeInfo.tm_wday - 1U) : (MAX_LAMPS - 1U);
+    uint8_t idx = 0U;
 
-    /* Last active lamp has to be deactivated. */
-    uint8_t lampToDeactivate = (0U < activeLamp) ? (activeLamp - 1U) : (MAX_LAMPS - 1U);
+    gfx.fillScreen(ColorDef::BLACK);
 
-    if (MAX_LAMPS > activeLamp)
+    m_textWidget.update(gfx);
+    while(MAX_LAMPS > idx)
     {
-        m_lampWidgets[activeLamp].setOnState(true);
-    }
+        m_lampWidgets[idx].update(gfx);
 
-    if (MAX_LAMPS > lampToDeactivate)
-    {
-        m_lampWidgets[lampToDeactivate].setOnState(false);
+        ++idx;
     }
+    /* Draw analog clock minute circle*/
+    drawAnalogClockBackground(gfx);
+
+    /* Draw analog clock hands. */
+    drawAnalogClockHand(gfx, m_now.tm_hour * 5 + m_now.tm_min / 12 , ANALOG_RADIUS - 12, ColorDef::GRAY);
+    drawAnalogClockHand(gfx, m_now.tm_min, ANALOG_RADIUS - 6, ColorDef::GRAY);
+    drawAnalogClockHand(gfx, m_now.tm_sec, ANALOG_RADIUS - 1, ColorDef::YELLOW);
+
+    /* Draw analog clock hand center */
+    gfx.drawRectangle(ANALOG_CENTER_X - 2, ANALOG_CENTER_Y - 2, 5, 5, ColorDef::YELLOW);
+    gfx.drawPixel(ANALOG_CENTER_X, ANALOG_CENTER_Y, ColorDef::BLACK);
+    gfx.drawPixel(ANALOG_CENTER_X-2, ANALOG_CENTER_Y-2, ColorDef::BLACK);
+    gfx.drawPixel(ANALOG_CENTER_X-2, ANALOG_CENTER_Y+2, ColorDef::BLACK);
+    gfx.drawPixel(ANALOG_CENTER_X+2, ANALOG_CENTER_Y-2, ColorDef::BLACK);
+    gfx.drawPixel(ANALOG_CENTER_X+2, ANALOG_CENTER_Y+2, ColorDef::BLACK);
+
+    //int16_t x, y;
+    //m_textWidget.getPos(x, y);
+    //gfx.fillRect(x, y, m_textWidget.getWidth(), m_textWidget.getHeight(), ColorDef::RED);
+    //m_textWidget.update(gfx);
 }
 
 /******************************************************************************
@@ -91,15 +155,50 @@ void DateTimeView64x64::setWeekdayIndicator(tm timeInfo)
  * Private Methods
  *****************************************************************************/
 
-void DateTimeView64x64::updateLampWidgetsColors()
+void DateTimeView64x64::drawAnalogClockBackground(YAGfx& gfx)
 {
-    uint8_t index;
+    /* draw minute ring */
+    uint16_t secondAngle(270u + m_now.tm_sec * 6u);
 
-    for(index = 0U; index < MAX_LAMPS; ++index)
+    for (uint16_t angle = 270u; angle < (270u + 360u); angle += 6u)
     {
-        m_lampWidgets[index].setColorOn(m_dayOnColor);
-        m_lampWidgets[index].setColorOff(m_dayOffColor);
+        int16_t dx(getMinuteCosinus(angle));
+        int16_t dy(getMinuteSinus(angle));
+
+        int16_t xs(ANALOG_CENTER_X + (dx * ANALOG_RADIUS) / SINUS_VAL_SCALE);
+        int16_t ys(ANALOG_CENTER_Y + (dy * ANALOG_RADIUS) / SINUS_VAL_SCALE);
+
+        if (0u == (angle % 30u))  /* Draw stronger marks at hour angles. */
+        {
+            int16_t xe(ANALOG_CENTER_X + (dx * (ANALOG_RADIUS - 4)) / SINUS_VAL_SCALE);
+            int16_t ye(ANALOG_CENTER_Y + (dy * (ANALOG_RADIUS - 4)) / SINUS_VAL_SCALE);
+
+            gfx.drawLine(xs, ys, xe, ye, ColorDef::BLUE);
+        }
+        else
+        {
+            /* Draw minute tick marks with passed seconds highlighting. */
+            Color tickMarkCol((angle <= secondAngle) ? ColorDef::YELLOW : ColorDef::DARKGRAY);
+            gfx.drawPixel(xs, ys, tickMarkCol);
+        }
     }
+}
+
+void DateTimeView64x64::drawAnalogClockHand(YAGfx& gfx, int16_t minute, int16_t radius, const Color& col)
+{
+    /* convert minute to angle starting at 270° which draws towards the top of the clock.*/
+    minute %= 60;
+    minute = 270 + minute * 6;
+
+    int16_t dx(getMinuteCosinus(minute));
+    int16_t dy(getMinuteSinus(minute));
+
+     gfx.drawLine(
+        ANALOG_CENTER_X + (3 * dx) / SINUS_VAL_SCALE,
+        ANALOG_CENTER_Y + (3 * dy) / SINUS_VAL_SCALE,
+        ANALOG_CENTER_X + (radius * dx) / SINUS_VAL_SCALE,
+        ANALOG_CENTER_Y + (radius * dy) / SINUS_VAL_SCALE,
+        col);
 }
 
 /******************************************************************************
@@ -109,3 +208,37 @@ void DateTimeView64x64::updateLampWidgetsColors()
 /******************************************************************************
  * Local Functions
  *****************************************************************************/
+
+static int16_t getMinuteSinus(uint16_t angle)
+{
+    angle %= 360u;
+
+    /*
+     * Lookup table only stores 1st quadrant sinus values.
+     * Others are calculated based on sinus curve symetries.
+     */
+    int16_t sinus(0);
+    if (90u >= angle)  /* quadrant 1 */
+    {
+        sinus = MINUTE_SIN_TAB[angle / 6u];
+    }
+    else if (180u >= angle) /* quadrant 2 is symetric to quadrant 1*/
+    {
+        sinus = MINUTE_SIN_TAB[(180u - angle) / 6u];
+    }
+    else if ( 270u >= angle)  /* quadrant 3 is point symetric to 2 */
+    {
+        sinus = (-1) * MINUTE_SIN_TAB[(angle - 180u) / 6u];
+    }
+    else /* quadrant 4 is symetric to 3 */
+    {
+        sinus = (-1) * MINUTE_SIN_TAB[(360 - angle) / 6u];
+    }
+
+    return sinus;
+}
+
+int16_t getMinuteCosinus(uint16_t angle)
+{
+    return getMinuteSinus(angle + 90u);
+}

--- a/lib/Views/src/layouts/DateTimeView64x64.cpp
+++ b/lib/Views/src/layouts/DateTimeView64x64.cpp
@@ -55,10 +55,10 @@ static const int16_t SINUS_VAL_SCALE = 10000;
  */
 enum SecondsDisplayMode
 {
-    SECOND_DISP_OFF  = 0u,    /**< no second indicator    */
-    SECOND_DISP_HAND = 1u,    /**< Draw second clock hand */
-    SECOND_DISP_RING = 2u,    /**< Show passed seconds on minute tick ring */
-    SECOND_DISP_BOTH = 3u,    /*< Show hand and on ring */
+    SECOND_DISP_OFF  = 0U,    /**< no second indicator    */
+    SECOND_DISP_HAND = 1U,    /**< Draw second clock hand */
+    SECOND_DISP_RING = 2U,    /**< Show passed seconds on minute tick ring */
+    SECOND_DISP_BOTH = 3U,    /*< Show hand and on ring */
 };
 
 /******************************************************************************
@@ -97,7 +97,7 @@ static SecondsDisplayMode gSecondsDisplayMode = SECOND_DISP_RING;
   *
   * Sinus value are stored as integer scaled by 10.000.
   */
-static const uint16_t MINUTE_SIN_TAB[16u] = {
+static const uint16_t MINUTE_SIN_TAB[16U] = {
     0,    /* sin(0°)   */
     1045, /* sin(6°)   */
     2079, /* sin(12°)  */
@@ -148,7 +148,7 @@ void DateTimeView64x64::update(YAGfx& gfx)
         drawAnalogClockHand(gfx, m_now.tm_min, ANALOG_RADIUS - 6, ColorDef::WHITE);
         drawAnalogClockHand(gfx, m_now.tm_hour * 5 + m_now.tm_min / 12 , ANALOG_RADIUS - 13, ColorDef::WHITESMOKE);
 
-        if (0u != (gSecondsDisplayMode & SECOND_DISP_HAND))
+        if (0U != (gSecondsDisplayMode & SECOND_DISP_HAND))
         {
             drawAnalogClockHand(gfx, m_now.tm_sec, ANALOG_RADIUS - 1, ColorDef::YELLOW);
         }
@@ -177,9 +177,9 @@ void DateTimeView64x64::update(YAGfx& gfx)
 void DateTimeView64x64::drawAnalogClockBackground(YAGfx& gfx)
 {
     /* draw minute ring */
-    uint16_t secondAngle(270u + m_now.tm_sec * 6u);
+    uint16_t secondAngle(270U + m_now.tm_sec * 6U);
 
-    for (uint16_t angle = 270u; angle < (270u + 360u); angle += 6u)
+    for (uint16_t angle = 270U; angle < (270U + 360U); angle += 6U)
     {
         int16_t dx(getMinuteCosinus(angle));
         int16_t dy(getMinuteSinus(angle));
@@ -187,7 +187,7 @@ void DateTimeView64x64::drawAnalogClockBackground(YAGfx& gfx)
         int16_t xs(ANALOG_CENTER_X + (dx * ANALOG_RADIUS) / SINUS_VAL_SCALE);
         int16_t ys(ANALOG_CENTER_Y + (dy * ANALOG_RADIUS) / SINUS_VAL_SCALE);
 
-        if (0u == (angle % 30u))  /* Draw stronger marks at hour angles. */
+        if (0U == (angle % 30U))  /* Draw stronger marks at hour angles. */
         {
             int16_t xe(ANALOG_CENTER_X + (dx * (ANALOG_RADIUS - 4)) / SINUS_VAL_SCALE);
             int16_t ye(ANALOG_CENTER_Y + (dy * (ANALOG_RADIUS - 4)) / SINUS_VAL_SCALE);
@@ -196,7 +196,7 @@ void DateTimeView64x64::drawAnalogClockBackground(YAGfx& gfx)
         }
 
         Color tickMarkCol(ColorDef::DARKGRAY);
-        if ((0u != (SECOND_DISP_RING & gSecondsDisplayMode)) && (angle <= secondAngle))
+        if ((0U != (SECOND_DISP_RING & gSecondsDisplayMode)) && (angle <= secondAngle))
         {
            /* Draw minute tick marks with passed seconds highlighting. */
            tickMarkCol = ColorDef::YELLOW;
@@ -232,28 +232,28 @@ void DateTimeView64x64::drawAnalogClockHand(YAGfx& gfx, int16_t minute, int16_t 
 
 static int16_t getMinuteSinus(uint16_t angle)
 {
-    angle %= 360u;
+    angle %= 360U;
 
     /*
      * Lookup table only stores 1st quadrant sinus values.
      * Others are calculated based on sinus curve symetries.
      */
     int16_t sinus(0);
-    if (90u >= angle)  /* quadrant 1 */
+    if (90U >= angle)  /* quadrant 1 */
     {
-        sinus = MINUTE_SIN_TAB[angle / 6u];
+        sinus = MINUTE_SIN_TAB[angle / 6U];
     }
-    else if (180u >= angle) /* quadrant 2 is symetric to quadrant 1*/
+    else if (180U >= angle) /* quadrant 2 is symetric to quadrant 1*/
     {
-        sinus = MINUTE_SIN_TAB[(180u - angle) / 6u];
+        sinus = MINUTE_SIN_TAB[(180U - angle) / 6U];
     }
-    else if ( 270u >= angle)  /* quadrant 3 is point symetric to 2 */
+    else if ( 270U >= angle)  /* quadrant 3 is point symetric to 2 */
     {
-        sinus = (-1) * MINUTE_SIN_TAB[(angle - 180u) / 6u];
+        sinus = (-1) * MINUTE_SIN_TAB[(angle - 180U) / 6U];
     }
     else /* quadrant 4 is symetric to 3 */
     {
-        sinus = (-1) * MINUTE_SIN_TAB[(360 - angle) / 6u];
+        sinus = (-1) * MINUTE_SIN_TAB[(360 - angle) / 6U];
     }
 
     return sinus;
@@ -261,5 +261,5 @@ static int16_t getMinuteSinus(uint16_t angle)
 
 int16_t getMinuteCosinus(uint16_t angle)
 {
-    return getMinuteSinus(angle + 90u);
+    return getMinuteSinus(angle + 90U);
 }

--- a/lib/Views/src/layouts/DateTimeView64x64.cpp
+++ b/lib/Views/src/layouts/DateTimeView64x64.cpp
@@ -44,7 +44,7 @@
  * Macros
  *****************************************************************************/
 
-/** Factor by which Sinu/cosinus values are scaled to use integer math.  */
+/** Factor by which sinus/cosinus values are scaled to use integer math.  */
 static const int16_t SINUS_VAL_SCALE = 10000;
 
 /******************************************************************************
@@ -55,10 +55,10 @@ static const int16_t SINUS_VAL_SCALE = 10000;
  */
 enum SecondsDisplayMode
 {
-    SECOND_DISP_OFF  = 0U,    /**< no second indicator    */
-    SECOND_DISP_HAND = 1U,    /**< Draw second clock hand */
-    SECOND_DISP_RING = 2U,    /**< Show passed seconds on minute tick ring */
-    SECOND_DISP_BOTH = 3U,    /*< Show hand and on ring */
+    SECOND_DISP_OFF  = 0U,    /**< No second indicator display. */
+    SECOND_DISP_HAND = 1U,    /**< Draw second clock hand. */
+    SECOND_DISP_RING = 2U,    /**< Show passed seconds on minute tick ring. */
+    SECOND_DISP_BOTH = 3U,    /**< Show hand and on ring. */
 };
 
 /******************************************************************************
@@ -141,7 +141,7 @@ void DateTimeView64x64::update(YAGfx& gfx)
             m_lampWidgets[idx].update(gfx);
         }
 
-        /* Draw analog clock minute circle*/
+        /* Draw analog clock minute circle. */
         drawAnalogClockBackground(gfx);
 
         /* Draw analog clock hands. */
@@ -152,6 +152,7 @@ void DateTimeView64x64::update(YAGfx& gfx)
         {
             drawAnalogClockHand(gfx, m_now.tm_sec, ANALOG_RADIUS - 1, ColorDef::YELLOW);
         }
+
         /* Draw analog clock hand center */
         gfx.drawRectangle(ANALOG_CENTER_X - 2, ANALOG_CENTER_Y - 2, 5, 5, ColorDef::YELLOW);
         gfx.drawPixel(ANALOG_CENTER_X, ANALOG_CENTER_Y, ColorDef::BLACK);
@@ -207,7 +208,7 @@ void DateTimeView64x64::drawAnalogClockBackground(YAGfx& gfx)
 
 void DateTimeView64x64::drawAnalogClockHand(YAGfx& gfx, int16_t minute, int16_t radius, const Color& col)
 {
-    /* convert minute to angle starting at 270° which draws towards the top of the clock.*/
+    /* Convert minute to angle starting at 270°, which draws towards the top of the clock. */
     minute %= 60;
     minute = 270 + minute * 6;
 

--- a/lib/Views/src/layouts/DateTimeView64x64.cpp
+++ b/lib/Views/src/layouts/DateTimeView64x64.cpp
@@ -56,9 +56,9 @@ static const int16_t SINUS_VAL_SCALE = 10000;
  *****************************************************************************/
 
 /**
-* @brief Get the Minute Siunus value
+* @brief Get the Minute Sinus value
 *
-* @param angle Minute angle, must be multiple of 6°  (360 °/ 60 minutes)
+* @param[in] angle Minute angle, must be multiple of 6°  (360 °/ 60 minutes)
 * @return sinus value for angle (scaled by 10.000)
 */
 static int16_t getMinuteSinus(uint16_t angle);
@@ -66,7 +66,7 @@ static int16_t getMinuteSinus(uint16_t angle);
 /**
  * @brief Get the Minute Cosinus value
  *
- * @param angle Minute angle, must be multiple of 6° (360 °/ 60 minutes)
+ * @param[in] angle Minute angle, must be multiple of 6° (360 °/ 60 minutes)
  * @return cosinus value for angle (scaled by 10.000)
  */
 static int16_t getMinuteCosinus(uint16_t angle);

--- a/lib/Views/src/layouts/DateTimeView64x64.cpp
+++ b/lib/Views/src/layouts/DateTimeView64x64.cpp
@@ -51,16 +51,6 @@ static const int16_t SINUS_VAL_SCALE = 10000;
  * Types and classes
  *****************************************************************************/
 
-/** Options for displaying seconds in analog clock
- */
-enum SecondsDisplayMode
-{
-    SECOND_DISP_OFF  = 0U,    /**< No second indicator display. */
-    SECOND_DISP_HAND = 1U,    /**< Draw second clock hand. */
-    SECOND_DISP_RING = 2U,    /**< Show passed seconds on minute tick ring. */
-    SECOND_DISP_BOTH = 3U,    /**< Show hand and on ring. */
-};
-
 /******************************************************************************
  * Prototypes
  *****************************************************************************/
@@ -68,7 +58,7 @@ enum SecondsDisplayMode
 /**
 * @brief Get the Minute Siunus value
 *
-* @param angle Minute angle, must be mutliple of 6°  (360 °/ 60 minutes)
+* @param angle Minute angle, must be multiple of 6°  (360 °/ 60 minutes)
 * @return sinus value for angle (scaled by 10.000)
 */
 static int16_t getMinuteSinus(uint16_t angle);
@@ -76,7 +66,7 @@ static int16_t getMinuteSinus(uint16_t angle);
 /**
  * @brief Get the Minute Cosinus value
  *
- * @param angle Minute angle, must be mutliple of 6° (360 °/ 60 minutes)
+ * @param angle Minute angle, must be multiple of 6° (360 °/ 60 minutes)
  * @return cosinus value for angle (scaled by 10.000)
  */
 static int16_t getMinuteCosinus(uint16_t angle);
@@ -85,19 +75,16 @@ static int16_t getMinuteCosinus(uint16_t angle);
  * Local Variables
  *****************************************************************************/
 
-/** Specify how to visualize seconds in analog clock. */
-static SecondsDisplayMode gSecondsDisplayMode = SECOND_DISP_RING;
-
 /**
-  * Sinus lookup table for analog clock drawing
-  *
-  * Holds sinus values for the minutes 0 .. 15 angles in quadarant 0.
-  * Other quadrants and cosinus values get derived from these values
-  * to avoid recalculations.
-  *
-  * Sinus value are stored as integer scaled by 10.000.
-  */
-static const uint16_t MINUTE_SIN_TAB[16U] = {
+ * Sinus lookup table for analog clock drawing
+ *
+ * Holds sinus values for the minutes 0 .. 15 angles in quadarant 0.
+ * Other quadrants and cosinus values get derived from these values
+ * to avoid recalculations.
+ *
+ * Sinus value are stored as integer scaled by 10.000.
+ */
+static const int16_t MINUTE_SIN_TAB[16U] = {
     0,    /* sin(0°)   */
     1045, /* sin(6°)   */
     2079, /* sin(12°)  */
@@ -145,10 +132,10 @@ void DateTimeView64x64::update(YAGfx& gfx)
         drawAnalogClockBackground(gfx);
 
         /* Draw analog clock hands. */
-        drawAnalogClockHand(gfx, m_now.tm_min, ANALOG_RADIUS - 6, ColorDef::WHITE);
-        drawAnalogClockHand(gfx, m_now.tm_hour * 5 + m_now.tm_min / 12 , ANALOG_RADIUS - 13, ColorDef::WHITESMOKE);
+        drawAnalogClockHand(gfx, m_now.tm_min, ANALOG_RADIUS - 6, ColorDef::GRAY);
+        drawAnalogClockHand(gfx, m_now.tm_hour * 5 + m_now.tm_min / 12 , ANALOG_RADIUS - 13, ColorDef::WHITE);
 
-        if (0U != (gSecondsDisplayMode & SECOND_DISP_HAND))
+        if (0U != (m_secondsDisplayMode & SECOND_DISP_HAND))
         {
             drawAnalogClockHand(gfx, m_now.tm_sec, ANALOG_RADIUS - 1, ColorDef::YELLOW);
         }
@@ -197,7 +184,7 @@ void DateTimeView64x64::drawAnalogClockBackground(YAGfx& gfx)
         }
 
         Color tickMarkCol(ColorDef::DARKGRAY);
-        if ((0U != (SECOND_DISP_RING & gSecondsDisplayMode)) && (angle <= secondAngle))
+        if ((0U != (SECOND_DISP_RING & m_secondsDisplayMode)) && (angle <= secondAngle))
         {
            /* Draw minute tick marks with passed seconds highlighting. */
            tickMarkCol = ColorDef::YELLOW;

--- a/lib/Views/src/layouts/DateTimeView64x64.h
+++ b/lib/Views/src/layouts/DateTimeView64x64.h
@@ -70,6 +70,7 @@ public:
      */
     DateTimeView64x64() :
         DateTimeViewGeneric(),
+        m_secondsDisplayMode(SECOND_DISP_RING),
         m_lastUpdateSecondVal(-1)
     {
         /* Disable fade effect in case the user required to show seconds,
@@ -103,10 +104,22 @@ public:
 
 protected:
 
+    /** Options for displaying seconds in analog clock
+     */
+    enum SecondsDisplayMode
+    {
+        SECOND_DISP_OFF = 0U,  /**< No second indicator display. */
+        SECOND_DISP_HAND = 1U, /**< Draw second clock hand. */
+        SECOND_DISP_RING = 2U, /**< Show passed seconds on minute tick ring. */
+        SECOND_DISP_BOTH = 3U, /**< Show hand and on ring. */
+    };
+
+    SecondsDisplayMode m_secondsDisplayMode; /**< How to visualize seconds in analog clock. */
+
+
     /**
      * Center x-coordinate of analog clock
      */
-
     static const int16_t ANALOG_CENTER_X     = 32;
 
     /**
@@ -119,6 +132,9 @@ protected:
      */
     static const int16_t ANALOG_RADIUS       = 31;
 
+    /**
+     * Seconds value of last display update. Used to avoid unecessary redrawing.
+     */
     int m_lastUpdateSecondVal;
 
     DateTimeView64x64(const DateTimeView64x64& other);

--- a/lib/Views/src/layouts/DateTimeView64x64.h
+++ b/lib/Views/src/layouts/DateTimeView64x64.h
@@ -68,7 +68,9 @@ public:
     /**
      * Construct the view.
      */
-    DateTimeView64x64() : DateTimeViewGeneric()
+    DateTimeView64x64() :
+        DateTimeViewGeneric(),
+        m_lastUpdateSecondVal(-1)
     {
         /* Disable fade effect in case the user required to show seconds,
          * which will continuously trigger the fading effect.
@@ -76,11 +78,11 @@ public:
         m_textWidget.disableFadeEffect();
 
         /*
-         * Move digital clock to lower paet of analog clock.
-         * Analog clock is also shifted in X by one as the 
-         * mid point is 31.5
+         * Move digital clock to lower part of analog clock.
+         * Analog clock is also shifted in X by one as the
+         * mid point is 32.
          */
-        m_textWidget.move(1, 46); 
+        m_textWidget.move(1, 47);
     }
 
     /**
@@ -92,51 +94,53 @@ public:
 
     /**
      * Update the underlying canvas.
-     * 
+     *
      * @param[in] gfx   Graphic functionality to draw on the underlying canvas.
      */
     void update(YAGfx& gfx) override;
 
-    
-    
+
+
 protected:
 
     /**
-     * Center x-coordinate of analog clock 
+     * Center x-coordinate of analog clock
      */
 
     static const int16_t ANALOG_CENTER_X     = 32;
 
     /**
-     * Center y-coordinate of analog clock 
+     * Center y-coordinate of analog clock
      */
     static const int16_t ANALOG_CENTER_Y     = 31;
 
     /**
-     * Anaolog Clock radius  
+     * Anaolog Clock radius
      */
     static const int16_t ANALOG_RADIUS       = 31;
+
+    int m_lastUpdateSecondVal;
 
     DateTimeView64x64(const DateTimeView64x64& other);
     DateTimeView64x64& operator=(const DateTimeView64x64& other);
 
     /**
      * Draw analog clock backround (the minute tick marks)
-     * 
+     *
      * @param[in] gfx   Graphic functionality to draw on the underlying canvas.
      */
     void drawAnalogClockBackground(YAGfx& gfx);
 
     /**
      * Draw analog clock hands for given time.
-     * 
+     *
      * @param[in] gfx   Graphic functionality to draw on the underlying canvas.
-     * @param[in] now current time 
+     * @param[in] now current time
      */
 
     /**
-     * @brief 
-     * 
+     * @brief
+     *
      * @param[in] gfx    Graphic functionality to draw on the underlying canvas.
      * @param[in] minute Minute to point to (0..59).
      * @param[in] radius Length of hand (radius from clock mid point)

--- a/lib/Views/src/layouts/DateTimeView64x64.h
+++ b/lib/Views/src/layouts/DateTimeView64x64.h
@@ -134,13 +134,6 @@ protected:
     /**
      * Draw analog clock hands for given time.
      *
-     * @param[in] gfx   Graphic functionality to draw on the underlying canvas.
-     * @param[in] now current time
-     */
-
-    /**
-     * @brief
-     *
      * @param[in] gfx    Graphic functionality to draw on the underlying canvas.
      * @param[in] minute Minute to point to (0..59).
      * @param[in] radius Length of hand (radius from clock mid point)

--- a/lib/Views/src/layouts/DateTimeView64x64.h
+++ b/lib/Views/src/layouts/DateTimeView64x64.h
@@ -43,7 +43,8 @@
  * Includes
  *****************************************************************************/
 #include <YAGfx.h>
-#include <IDateTimeView.h>
+#include "DateTimeViewGeneric.h"
+
 #include <Fonts.h>
 #include <LampWidget.h>
 #include <TextWidget.h>
@@ -60,31 +61,26 @@
 /**
  * View for 64x64 LED matrix with date and time.
  */
-class DateTimeView64x64 : public IDateTimeView
+class DateTimeView64x64 : public DateTimeViewGeneric
 {
 public:
 
     /**
      * Construct the view.
      */
-    DateTimeView64x64() :
-        IDateTimeView(),
-        m_fontType(Fonts::FONT_TYPE_DEFAULT),
-        m_textWidget(TEXT_WIDTH, TEXT_HEIGHT, TEXT_X, TEXT_Y),
-        m_lampWidgets{{LAMP_WIDTH, LAMP_HEIGHT, LAMP_0_X , LAMP_Y},
-                      {LAMP_WIDTH, LAMP_HEIGHT, LAMP_1_X , LAMP_Y},
-                      {LAMP_WIDTH, LAMP_HEIGHT, LAMP_2_X , LAMP_Y},
-                      {LAMP_WIDTH, LAMP_HEIGHT, LAMP_3_X , LAMP_Y},
-                      {LAMP_WIDTH, LAMP_HEIGHT, LAMP_4_X , LAMP_Y},
-                      {LAMP_WIDTH, LAMP_HEIGHT, LAMP_5_X , LAMP_Y},
-                      {LAMP_WIDTH, LAMP_HEIGHT, LAMP_6_X , LAMP_Y}},
-        m_dayOnColor(DAY_ON_COLOR),
-        m_dayOffColor(DAY_OFF_COLOR)
+    DateTimeView64x64() : DateTimeViewGeneric()
     {
         /* Disable fade effect in case the user required to show seconds,
          * which will continuously trigger the fading effect.
          */
         m_textWidget.disableFadeEffect();
+
+        /*
+         * Move digital clock to lower paet of analog clock.
+         * Analog clock is also shifted in X by one as the 
+         * mid point is 31.5
+         */
+        m_textWidget.move(1, 46); 
     }
 
     /**
@@ -95,217 +91,58 @@ public:
     }
 
     /**
-     * Initialize view, which will prepare the widgets and the default values.
-     */
-    void init(uint16_t width, uint16_t height) override
-    {
-        UTIL_NOT_USED(width);
-        UTIL_NOT_USED(height);
-
-        m_textWidget.setFormatStr("{hc}No NTP");
-        updateLampWidgetsColors();
-    }
-
-    /**
-     * Get font type.
-     * 
-     * @return The font type the view uses.
-     */
-    Fonts::FontType getFontType() const override
-    {
-        return m_fontType;
-    }
-
-    /**
-     * Set font type.
-     * 
-     * @param[in] fontType  The font type which the view shall use.
-     */
-    void setFontType(Fonts::FontType fontType) override
-    {
-        m_fontType = fontType;
-        m_textWidget.setFont(Fonts::getFontByType(m_fontType));
-    }
-
-    /**
      * Update the underlying canvas.
      * 
      * @param[in] gfx   Graphic functionality to draw on the underlying canvas.
      */
-    void update(YAGfx& gfx) override
-    {
-        uint8_t idx = 0U;
+    void update(YAGfx& gfx) override;
 
-        gfx.fillScreen(ColorDef::BLACK);
-        m_textWidget.update(gfx);
-
-        while(MAX_LAMPS > idx)
-        {
-            m_lampWidgets[idx].update(gfx);
-
-            ++idx;
-        }
-    }
-
-    /**
-     * Get text (non-formatted).
-     * 
-     * @return Text
-     */
-    String getText() const override
-    {
-        return m_textWidget.getStr();
-    }
-
-    /**
-     * Get text (formatted).
-     * 
-     * @return Text
-     */
-    String getFormatText() const override
-    {
-        return m_textWidget.getFormatStr();
-    }
-
-    /**
-     * Set text (formatted).
-     * 
-     * @param[in] formatText    Formatted text to show.
-     */
-    void setFormatText(const String& formatText) override
-    {
-        m_textWidget.setFormatStr(formatText);
-    }
-
-    /**
-     * Get the color to show the actual day.
-     * 
-     * @return Color
-     */
-    const Color& getDayOnColor() const override
-    {
-        return m_dayOnColor;
-    }
-
-    /**
-     * Set the color which is used for the actual day.
-     * 
-     * @param[in] color Color for the actual day
-     */
-    void setDayOnColor(const Color& color) override
-    {
-        m_dayOnColor = color;
-        updateLampWidgetsColors();
-    }
-
-    /**
-     * Get the color to show the other days than the actual one.
-     * 
-     * @return Color
-     */
-    const Color& getDayOffColor() const override
-    {
-        return m_dayOffColor;
-    }
-
-    /**
-     * Set the color which is used for the other days than the actual day.
-     * 
-     * @param[in] color Color for the other days
-     */
-    void setDayOffColor(const Color& color) override
-    {
-        m_dayOffColor = color;
-        updateLampWidgetsColors();
-    }
-
-    /**
-     * Set weekday indicator depended on the given time info.
-     *
-     * @param[in] timeInfo the current time info.
-     */
-    void setWeekdayIndicator(tm timeInfo) override;
-
-    /** Max. number of lamps. One lamp per day in a week. */
-    static const uint8_t    MAX_LAMPS       = 7U;
-
+    
+    
 protected:
 
-    /** Distance between two lamps in pixel. */
-    static const uint8_t    LAMP_DISTANCE   = 1U;
+    /**
+     * Center x-coordinate of analog clock 
+     */
 
-    /** Lamp width in pixel. */
-    static const uint8_t    LAMP_WIDTH      = (CONFIG_LED_MATRIX_WIDTH - ((MAX_LAMPS + 1U) * LAMP_DISTANCE)) / MAX_LAMPS;
-
-    /** Lamp distance to the canvas border in pixel. */
-    static const uint8_t    LAMP_BORDER     = (CONFIG_LED_MATRIX_WIDTH - (MAX_LAMPS * LAMP_WIDTH) - ((MAX_LAMPS - 1U) * LAMP_DISTANCE)) / 2U;
-
-    /** Lamp height in pixel. */
-    static const uint8_t    LAMP_HEIGHT     = 1U;
-
-    /** Lamp 0 x-coordinate in pixel. */
-    static const uint8_t    LAMP_0_X        = LAMP_BORDER + (0 * (LAMP_WIDTH + LAMP_DISTANCE));
-
-    /** Lamp 1 x-coordinate in pixel. */
-    static const uint8_t    LAMP_1_X        = LAMP_BORDER + (1 * (LAMP_WIDTH + LAMP_DISTANCE));
-
-    /** Lamp 2 x-coordinate in pixel. */
-    static const uint8_t    LAMP_2_X        = LAMP_BORDER + (2 * (LAMP_WIDTH + LAMP_DISTANCE));
-
-    /** Lamp 3 x-coordinate in pixel. */
-    static const uint8_t    LAMP_3_X        = LAMP_BORDER + (3 * (LAMP_WIDTH + LAMP_DISTANCE));
-
-    /** Lamp 4 x-coordinate in pixel. */
-    static const uint8_t    LAMP_4_X        = LAMP_BORDER + (4 * (LAMP_WIDTH + LAMP_DISTANCE));
-
-    /** Lamp 5 x-coordinate in pixel. */
-    static const uint8_t    LAMP_5_X        = LAMP_BORDER + (5 * (LAMP_WIDTH + LAMP_DISTANCE));
-
-    /** Lamp 6 x-coordinate in pixel. */
-    static const uint8_t    LAMP_6_X        = LAMP_BORDER + (6 * (LAMP_WIDTH + LAMP_DISTANCE));
-
-    /** Lamp y-coordindate in pixel. */
-    static const uint8_t    LAMP_Y          = CONFIG_LED_MATRIX_HEIGHT - 1U;
+    static const int16_t ANALOG_CENTER_X     = 32;
 
     /**
-     * Text width in pixels.
+     * Center y-coordinate of analog clock 
      */
-    static const uint16_t   TEXT_WIDTH      = CONFIG_LED_MATRIX_WIDTH;
+    static const int16_t ANALOG_CENTER_Y     = 31;
 
     /**
-     * Text height in pixels.
+     * Anaolog Clock radius  
      */
-    static const uint16_t   TEXT_HEIGHT     = CONFIG_LED_MATRIX_HEIGHT - LAMP_HEIGHT;
-
-    /**
-     * Text widget x-coordinate in pixels.
-     */
-    static const int16_t    TEXT_X          = 0;
-
-    /**
-     * Text widget y-coordinate in pixels.
-     */
-    static const int16_t    TEXT_Y          = 0;
-
-    /** Color of the current day shown in the day of the week bar. */
-    static const Color      DAY_ON_COLOR;
-
-    /** Color of the other days (not the current one) shown in the day of the week bar. */
-    static const Color      DAY_OFF_COLOR;
-
-    Fonts::FontType m_fontType;                 /**< Font type which shall be used if there is no conflict with the layout. */
-    TextWidget      m_textWidget;               /**< Text widget, used for showing the text. */
-    LampWidget      m_lampWidgets[MAX_LAMPS];   /**< Lamp widgets, used to signal the day of week. */
-    Color           m_dayOnColor;               /**< Color of current day in the day of the week bar. */
-    Color           m_dayOffColor;              /**< Color of the other days in the day of the week bar. */
+    static const int16_t ANALOG_RADIUS       = 31;
 
     DateTimeView64x64(const DateTimeView64x64& other);
     DateTimeView64x64& operator=(const DateTimeView64x64& other);
 
     /**
-     * Updates all colors of the lamp widgets.
+     * Draw analog clock backround (the minute tick marks)
+     * 
+     * @param[in] gfx   Graphic functionality to draw on the underlying canvas.
      */
-    void updateLampWidgetsColors();
+    void drawAnalogClockBackground(YAGfx& gfx);
+
+    /**
+     * Draw analog clock hands for given time.
+     * 
+     * @param[in] gfx   Graphic functionality to draw on the underlying canvas.
+     * @param[in] now current time 
+     */
+
+    /**
+     * @brief 
+     * 
+     * @param[in] gfx    Graphic functionality to draw on the underlying canvas.
+     * @param[in] minute Minute to point to (0..59).
+     * @param[in] radius Length of hand (radius from clock mid point)
+     * @param[in] col    Color of the hand.
+     */
+    void drawAnalogClockHand(YAGfx& gfx, int16_t minute, int16_t radius, const Color& col);
 };
 
 /******************************************************************************

--- a/lib/Views/src/layouts/DateTimeViewGeneric.cpp
+++ b/lib/Views/src/layouts/DateTimeViewGeneric.cpp
@@ -64,10 +64,14 @@ const Color DateTimeViewGeneric::DAY_OFF_COLOR = ColorDef::ULTRADARKGRAY;
  * Public Methods
  *****************************************************************************/
 
-void DateTimeViewGeneric::setWeekdayIndicator(tm timeInfo)
+void DateTimeViewGeneric::setCurrentTime(const tm& now)
 {
+    m_now = now;
+
+    /* update lamp widgets */
+
     /* tm_wday starts at sunday, first lamp indicates monday.*/
-    uint8_t activeLamp = (0U < timeInfo.tm_wday) ? (timeInfo.tm_wday - 1U) : (MAX_LAMPS - 1U);
+    uint8_t activeLamp = (0U < m_now.tm_wday) ? (m_now.tm_wday - 1U) : (MAX_LAMPS - 1U);
 
     /* Last active lamp has to be deactivated. */
     uint8_t lampToDeactivate = (0U < activeLamp) ? (activeLamp - 1U) : (MAX_LAMPS - 1U);

--- a/lib/Views/src/layouts/DateTimeViewGeneric.h
+++ b/lib/Views/src/layouts/DateTimeViewGeneric.h
@@ -79,7 +79,8 @@ public:
                       {LAMP_WIDTH, LAMP_HEIGHT, LAMP_5_X , LAMP_Y},
                       {LAMP_WIDTH, LAMP_HEIGHT, LAMP_6_X , LAMP_Y}},
         m_dayOnColor(DAY_ON_COLOR),
-        m_dayOffColor(DAY_OFF_COLOR)
+        m_dayOffColor(DAY_OFF_COLOR),
+        m_now()
     {
         /* Disable fade effect in case the user required to show seconds,
          * which will continuously trigger the fading effect.
@@ -220,11 +221,11 @@ public:
     }
 
     /**
-     * Set weekday indicator depended on the given time info.
-     *
-     * @param[in] timeInfo the current time info.
+     * @brief Update current time values in view
+     * 
+     * @param now current time
      */
-    void setWeekdayIndicator(tm timeInfo) override;
+    virtual void setCurrentTime(const tm& now) override;
 
     /** Max. number of lamps. One lamp per day in a week. */
     static const uint8_t    MAX_LAMPS       = 7U;
@@ -298,6 +299,7 @@ protected:
     LampWidget      m_lampWidgets[MAX_LAMPS];   /**< Lamp widgets, used to signal the day of week. */
     Color           m_dayOnColor;               /**< Color of current day in the day of the week bar. */
     Color           m_dayOffColor;              /**< Color of the other days in the day of the week bar. */
+    tm              m_now;                      /**< Latest time update */
 
     DateTimeViewGeneric(const DateTimeViewGeneric& other);
     DateTimeViewGeneric& operator=(const DateTimeViewGeneric& other);


### PR DESCRIPTION

Utilize 64x64 layout to enhance DateTimePlugin to show time also using an  analog clock.

Note: API change: Replace API setWeekdayIndicator with setCurrentTime. The new new better describes the purpose as it updates every second.

32x8 Display backward compatibility testes with Lilygo-T-Display-S3.

