### PR TITLE
Added help terminal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Connect PIXELIX with your PC via usb and start a terminal. Use the following com
   * A status of 0 means everything is ok.
   * Other than 0, see their meaning in the low [low level error code table](#the-display-only-shows-a-error-code-like-e4-what-does-that-mean). Note, the status of 1 is equal to E1 in the error code table and etc.
 
+Enter ```help``` to get a list of all supported commands.
+
 ## PIXELIX Is Ready
 After configuration, restart again and voila, PIXELIX will be available in your wifi network.
 

--- a/src/Common/MiniTerminal.h
+++ b/src/Common/MiniTerminal.h
@@ -107,19 +107,31 @@ public:
         return isRestartRequested;
     }
 
+    /**
+     * @brief Table entry for known terminal commands
+     * 
+     */
+    struct CmdTableEntry {
+        const char *cmdStr;                           /**< Command string.           */
+        size_t cmdLen;                                /**< Length of command string. */
+        void (MiniTerminal::*handler)(const char *);  /**< Command handler function. */
+    };
+
 private:
 
     static const char   ASCII_BS            = 8;    /**< ASCII backspace value */
     static const char   ASCII_LF            = 10;   /**< ASCII line feed value */
     static const char   ASCII_SP            = 32;   /**< ASCII space value */
     static const char   ASCII_DEL           = 127;  /**< ASCII delete value */
-    static const size_t LOCAL_BUFFER_SIZE   = 10U;  /**< Buffer size in byte to read during processing. */
+    static const size_t LOCAL_BUFFER_SIZE   = 12U;  /**< Buffer size in byte to read during processing. */
     static const size_t INPUT_BUFFER_SIZE   = 80U;  /**< Buffer size of one input command line in byte. */
 
     Stream& m_stream;                   /**< In/Out-stream. */
     char    m_input[INPUT_BUFFER_SIZE]; /**< Input command line buffer. */
     size_t  m_writeIndex;               /**< Write index to the command line buffer. */
     bool    m_isRestartRequested;       /**< Restart requested? */
+
+    static const CmdTableEntry m_cmdTable[]; /**< Table with supported commands. */
 
     /**
      * Write successful response.
@@ -183,6 +195,13 @@ private:
      * @param[in] par   Parameter
      */
     void cmdGetStatus(const char* par);
+
+    /**
+     * print command help message.
+     * 
+     * @param[in] par   Parameter
+     */
+    void cmdHelp(const char* par);
 };
 
 /******************************************************************************


### PR DESCRIPTION
Added new command help to print the supported commands list.

Side changes:
* Store cmd list in a table instead of if-else chain testing.
* Avoid unneeded dynamic construction of static variables (strlen calls)
* Read up to 12 bytes in process ( 32bit aligned to avoid gab byte loss of no gain).