### PR TITLE
ON_AP_FILTER() always returned false

### DIFF
--- a/config/mcu.ini
+++ b/config/mcu.ini
@@ -20,6 +20,7 @@ build_flags =
     -I ./src/Restart
     -I ./src/Web
     -I ./src/Web/WsCommand
+    -D SOC_WIFI_SUPPORTED=1 ; AsyncWebserver requires this. Can be removed with Arduino 3.x.x
     -D CONFIG_ASYNC_TCP_RUNNING_CORE=APP_CPU_NUM
     -D CONFIG_ASYNC_TCP_USE_WDT=1
     -D CONFIG_ASYNC_TCP_STACK_SIZE=8192

--- a/data/version.json
+++ b/data/version.json
@@ -1,3 +1,3 @@
 {
-    "version": "v9.0.0"
+    "version": "v9.0.1"
 }

--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = Pixelix
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v9.0.0
+PROJECT_NUMBER         = v9.0.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewers a


### PR DESCRIPTION
Arduino 3.x.x introduced new pre-processor defines like SOC_WIFI_SUPPORTED. Arduino 2.x.x misses them and therefore the ON_AP_FILTER() always returned false.

https://github.com/ESP32Async/ESPAsyncWebServer/discussions/247

#270 